### PR TITLE
リダイレクトURLに server port が含まれない問題

### DIFF
--- a/src/Pinoco/FlowControlHttpRedirect.php
+++ b/src/Pinoco/FlowControlHttpRedirect.php
@@ -44,6 +44,9 @@ class Pinoco_FlowControlHttpRedirect extends Pinoco_FlowControlHttpError {
     {
         $protocol = (array_key_exists('HTTPS', $_SERVER) && $_SERVER['HTTPS']) ? "https" : "http";
         $server_prefix = $protocol . '://' . $_SERVER['SERVER_NAME'];
+        if ($_SERVER['SERVER_PORT'] != "80") {
+            $server_prefix = $server_prefix . ":" . $_SERVER['SERVER_PORT'];
+        }
         $fixedurl = "";
         if(preg_match('/^\w+:\/\/[^\/]/', $this->url)) {
             $fixedurl = $this->url;


### PR DESCRIPTION
リダイレクトURLの組み立てに server port が含まれないので、追加しました。
