### PR TITLE
Add commands and CI for QA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /.settings/
 /nbproject/
 
+.php_cs.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,5 @@ before_script:
   - if [[ $TRAVIS_PHP_VERSION = '7.1' ]]; then composer require --dev phpstan/phpstan-shim friendsofphp/php-cs-fixer; fi
 script:
   - ./vendor/bin/phpunit $COVERAGE;
-  - if [[ $TRAVIS_PHP_VERSION = '7.1' ]]; then IFS=$'\n'; COMMIT_SCA_FILES=($(git diff --name-only --diff-filter=ACMRTUXB "${TRAVIS_COMMIT_RANGE}")); unset IFS && ./vendor/bin/php-cs-fixer fix ./ --rules=@PSR2 -v --dry-run --stop-on-violation --using-cache=no --path-mode=intersection -- "${COMMIT_SCA_FILES[@]}";fi
+  - if [[ $TRAVIS_PHP_VERSION = '7.1' ]]; then IFS=$'\n'; COMMIT_SCA_FILES=($(git diff --name-only --diff-filter=ACMRTUXB "${TRAVIS_COMMIT_RANGE}")); unset IFS && ./vendor/bin/php-cs-fixer fix ./ --rules=@PSR2 -v --dry-run --using-cache=no -- "${COMMIT_SCA_FILES[@]}";fi
   - if [[ $TRAVIS_PHP_VERSION = '7.1' ]]; then ./vendor/bin/phpstan analyse -l max -c phpstan.neon src tests --no-progress --no-interaction; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+sudo: false
 php:
   - 5.4
   - 5.5
@@ -7,11 +8,24 @@ php:
   - 7.1
   - 7.2
   - hhvm
+cache:
+  directories:
+    - vendor
+    - $HOME/.composer/cache
+env:
+  matrix:
+    - DEPENDENCIES=""
+    - DEPENDENCIES="--prefer-lowest --prefer-stable"
 matrix:
   include:
     - php: 5.3
       dist: precise
 before_script:
   - composer self-update
-  - composer update
-script: ./vendor/bin/phpunit
+  - composer update $DEPENDENCIES
+  - if [[ $TRAVIS_PHP_VERSION = '7.1' ]]; then COVERAGE="--coverage-clover=coverage.clover"; else phpenv config-rm xdebug.ini; fi
+  - if [[ $TRAVIS_PHP_VERSION = '7.1' ]]; then composer require --dev phpstan/phpstan-shim friendsofphp/php-cs-fixer; fi
+script:
+  - ./vendor/bin/phpunit $COVERAGE;
+  - if [[ $TRAVIS_PHP_VERSION = '7.1' ]]; then IFS=$'\n'; COMMIT_SCA_FILES=($(git diff --name-only --diff-filter=ACMRTUXB "${TRAVIS_COMMIT_RANGE}")); unset IFS && ./vendor/bin/php-cs-fixer fix ./ --rules=@PSR2 -v --dry-run --stop-on-violation --using-cache=no --path-mode=intersection -- "${COMMIT_SCA_FILES[@]}";fi
+  - if [[ $TRAVIS_PHP_VERSION = '7.1' ]]; then ./vendor/bin/phpstan analyse -l max -c phpstan.neon src tests --no-progress --no-interaction; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,20 +12,16 @@ cache:
   directories:
     - vendor
     - $HOME/.composer/cache
-env:
-  matrix:
-    - DEPENDENCIES=""
-    - DEPENDENCIES="--prefer-lowest --prefer-stable"
 matrix:
   include:
     - php: 5.3
       dist: precise
 before_script:
   - composer self-update
-  - composer update $DEPENDENCIES
+  - composer update
   - if [[ $TRAVIS_PHP_VERSION = '7.1' ]]; then COVERAGE="--coverage-clover=coverage.clover"; else phpenv config-rm xdebug.ini; fi
   - if [[ $TRAVIS_PHP_VERSION = '7.1' ]]; then composer require --dev phpstan/phpstan-shim friendsofphp/php-cs-fixer; fi
 script:
   - ./vendor/bin/phpunit $COVERAGE;
   - if [[ $TRAVIS_PHP_VERSION = '7.1' ]]; then IFS=$'\n'; COMMIT_SCA_FILES=($(git diff --name-only --diff-filter=ACMRTUXB "${TRAVIS_COMMIT_RANGE}")); unset IFS && ./vendor/bin/php-cs-fixer fix ./ --rules=@PSR2 -v --dry-run --using-cache=no -- "${COMMIT_SCA_FILES[@]}";fi
-  - if [[ $TRAVIS_PHP_VERSION = '7.1' ]]; then ./vendor/bin/phpstan analyse -l max -c phpstan.neon src tests --no-progress --no-interaction; fi
+  - if [[ $TRAVIS_PHP_VERSION = '7.1' ]]; then ./vendor/bin/phpstan analyse -l max -c phpstan.neon src test --no-progress --no-interaction; fi

--- a/composer.json
+++ b/composer.json
@@ -28,5 +28,14 @@
         "psr-0": {
             "Pinoco": "src/"
         }
+    },
+    "scripts" :{
+        "test": ["./vendor/bin/phpunit"],
+        "tests": ["@cs", "@phmd", "@phpstan", "@test"],
+        "coverage": ["php -dzend_extension=xdebug.so ./vendor/bin/phpunit --coverage-text --coverage-html=build/coverage"],
+        "cs": ["php-cs-fixer fix ./ -v --dry-run --rules=@PSR2"],
+        "cs-fix": ["php-cs-fixer fix ./ -v"],
+        "phpmd":  "phpmd src,test text ./phpmd.xml",
+        "phpstan": "phpstan analyse -l max -c phpstan.neon src test --no-progress --no-interaction"
     }
 }

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -1,0 +1,40 @@
+<ruleset xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
+         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+    <!--codesize-->
+    <rule ref="rulesets/codesize.xml/CyclomaticComplexity" />
+    <rule ref="rulesets/codesize.xml/NPathComplexity" />
+    <rule ref="rulesets/codesize.xml/ExcessiveClassComplexity" />
+    <rule ref="rulesets/codesize.xml/ExcessiveClassLength" />
+    <rule ref="rulesets/codesize.xml/ExcessiveMethodLength" />
+    <rule ref="rulesets/codesize.xml/ExcessiveParameterList" />
+    <rule ref="rulesets/codesize.xml/ExcessivePublicCount" />
+    <rule ref="rulesets/codesize.xml/TooManyFields" />
+    <rule ref="rulesets/codesize.xml/TooManyMethods" />
+    <!--design-->
+    <rule ref="rulesets/design.xml/EvalExpression" />
+    <rule ref="rulesets/design.xml/ExitExpression" />
+    <rule ref="rulesets/design.xml/GotoStatement" />
+    <rule ref="rulesets/design.xml/NumberOfChildren" />
+    <rule ref="rulesets/design.xml/DepthOfInheritance" />
+    <rule ref="rulesets/design.xml/CouplingBetweenObjects" />
+    <!--naming-->
+    <rule ref="rulesets/naming.xml/ConstantNamingConventions" />
+    <rule ref="rulesets/naming.xml/BooleanGetMethodName" />
+    <!--unusedcode-->
+    <rule ref="rulesets/unusedcode.xml/UnusedFormalParameter" />
+    <rule ref="rulesets/unusedcode.xml/UnusedLocalVariable" />
+    <rule ref="rulesets/unusedcode.xml/UnusedPrivateField" />
+    <rule ref="rulesets/unusedcode.xml/UnusedPrivateMethod" />
+    <!--controversial-->
+    <rule ref="rulesets/controversial.xml/Superglobals" />
+    <rule ref="rulesets/controversial.xml/CamelCaseClassName" />
+    <rule ref="rulesets/controversial.xml/CamelCasePropertyName" />
+    <rule ref="rulesets/controversial.xml/CamelCaseMethodName" />
+    <rule ref="rulesets/controversial.xml/CamelCaseParameterName" />
+    <rule ref="rulesets/controversial.xml/CamelCaseVariableName" />
+    <!--cleancode-->
+    <rule ref="rulesets/cleancode.xml/BooleanArgumentFlag" />
+    <rule ref="rulesets/cleancode.xml/ElseExpression" />
+</ruleset>


### PR DESCRIPTION
Added composer command and CI script for quality assurance.
Will this help for future release ?

# Composer Commands

* `composer test` for phpunit test
* `composer coverage` for test coverage
* `composer cs` for coding standard check
* `composer cs-fix` for coding standard fix
* `composer phpmd` for static analysis (1)
* `composer phpstan` for static analysis (2)
* `composer tests` for all tests above


# Travis CI

In addition to phpunit test, test as well as ...
* lowest dependencies
* coding standards
* static analysis by phpstan 
